### PR TITLE
Refresh icons view when switching between portrait and landscape

### DIFF
--- a/src/com/cyanogenmod/filemanager/activities/NavigationActivity.java
+++ b/src/com/cyanogenmod/filemanager/activities/NavigationActivity.java
@@ -802,6 +802,7 @@ public class NavigationActivity extends Activity
         if (mActiveDialog != null && mOnConfigChangeListener != null) {
             mOnConfigChangeListener.onConfigurationChanged(newConfig);
         }
+        getCurrentNavigationView().refreshViewMode();
     }
 
     /**

--- a/src/com/cyanogenmod/filemanager/ui/widgets/NavigationView.java
+++ b/src/com/cyanogenmod/filemanager/ui/widgets/NavigationView.java
@@ -843,6 +843,18 @@ BreadcrumbListener, OnSelectionChangedListener, OnSelectionListener, OnRequestRe
     }
 
     /**
+     * Method that refreshes the Icons layout mode.
+     * This is currently called for refreshing Icons layout mode when switching between portrait
+     * and landscape. Other layout modes don't need to be refreshed due to list view display
+     */
+    public void refreshViewMode() {
+        if (this.mCurrentMode.compareTo(NavigationLayoutMode.ICONS) == 0) {
+            this.mCurrentMode = null;
+            changeViewMode(NavigationLayoutMode.ICONS);
+        }
+    }
+
+    /**
      * Method that change the view mode.
      *
      * @param newMode The new mode


### PR DESCRIPTION
When switching between portrait and landscape modes, the icons view
needs to be updated to re-arrange the icons based on updated width.

Added a new method for refreshing icons view mode. This method is
called during orientation changes.

Issue-Id: FEIJ-492

Change-Id: I9c95357a7d4f57b223147e774838e4fdc19f5e89