### PR TITLE
Filter display of non-relevant results in search results

### DIFF
--- a/src/com/cyanogenmod/filemanager/activities/SearchActivity.java
+++ b/src/com/cyanogenmod/filemanager/activities/SearchActivity.java
@@ -112,6 +112,8 @@ public class SearchActivity extends Activity
 
     private static boolean DEBUG = false;
 
+    private static int INVALID_RELEVANCE = 1;
+
     /**
      * An {@link Intent} action for restore view information.
      */
@@ -864,7 +866,7 @@ public class SearchActivity extends Activity
             }
             if (success) {
                 // add to adapter
-                if (mResult.getRelevance() > 1) {
+                if (mResult.getRelevance() > INVALID_RELEVANCE) {
                     activity.mAdapter.addNewItem(mHolder);
                 }
                 int progress = activity.mAdapter.resultsSize();
@@ -1480,10 +1482,11 @@ public class SearchActivity extends Activity
                     new Query().fillSlots(mQuery.getQueries()));
 
             for (SearchResult result : newResults) {
-                // Only show results that are within our category, or all if no filter is set
-                if (MimeTypeHelper.MimeTypeCategory.NONE.equals(category)
-                        || MimeTypeHelper.getCategory(SearchActivity.this,
-                        result.getFso()).equals(category)) {
+                // Show all results that are relevant if no filter is set or show results that are
+                // relevant and match the specified category
+                if (result.getRelevance() > INVALID_RELEVANCE && (MimeTypeHelper.MimeTypeCategory
+                        .NONE.equals(category) || MimeTypeHelper.getCategory(SearchActivity.this,
+                        result.getFso()).equals(category))) {
                     results.add(generateDataHolder(result));
                 }
             }


### PR DESCRIPTION
When user switches between different category types in the search
results, any non-relevant entries should be filtered out.

Added check for filtering out non-relevant search results.

Issue-Id: FEIJ-517

Change-Id: I7f92819b362720d58860e41d7252cd43cbece808