### PR TITLE
Flush the shell console after each command

### DIFF
--- a/src/com/cyanogenmod/filemanager/console/shell/ShellConsole.java
+++ b/src/com/cyanogenmod/filemanager/console/shell/ShellConsole.java
@@ -654,6 +654,7 @@ public abstract class ShellConsole extends Console implements Program.ProgramLis
                    this.mFinished = false;
                    this.mNewData = false;
                    this.mOut.write(sb.toString().getBytes());
+                   this.mOut.flush();
                }
             } catch (InvalidCommandDefinitionException icdEx) {
                 throw new CommandNotFoundException(
@@ -1133,6 +1134,7 @@ public abstract class ShellConsole extends Console implements Program.ProgramLis
             //Test write something to the buffer
             this.mOut.write(FileHelper.NEWLINE.getBytes());
             this.mOut.write(FileHelper.NEWLINE.getBytes());
+            this.mOut.flush();
         } catch (IOException ioex) {
             //Something is wrong with the buffers. Reallocate console.
             Log.w(TAG,


### PR DESCRIPTION
This patch fixes the file manager on android-n-preview-2 (and maybe
other roms/systems). Observed behavior: no output is produced at StdIn
or StdErr after writing commands to the shell console. This leads to a
timeout and a reallocation of the console in an endless loop. Flushing
the output stream fixes the problem. Not sure if there was a good reason
for not doing it in general.

Change-Id: Ia87aa5065f6c62f133de4bbde4b4a32a4388d784