### PR TITLE
CMFM: Make sure no NPE happens

### DIFF
--- a/src/com/cyanogenmod/filemanager/console/secure/SecureConsole.java
+++ b/src/com/cyanogenmod/filemanager/console/secure/SecureConsole.java
@@ -624,6 +624,10 @@ public class SecureConsole extends VirtualMountPointConsole {
      */
     private void clearCache(Context ctx) {
         File filesDir = ctx.getExternalFilesDir(null);
+        if (filesDir == null) {
+            return;
+        }
+
         File[] cacheFiles = filesDir.listFiles(new FilenameFilter() {
             @Override
             public boolean accept(File dir, String filename) {


### PR DESCRIPTION
Fix for the case when getExternalFilesDir returns null

Change-Id: I62725cec0f65412f3cc9c66c0e9870d2da62c6b8