### PR TITLE
Filter out vnd.android.cursor mimetype for Picker

### DIFF
--- a/src/com/cyanogenmod/filemanager/activities/PickerActivity.java
+++ b/src/com/cyanogenmod/filemanager/activities/PickerActivity.java
@@ -255,7 +255,8 @@ public class PickerActivity extends Activity
         //- Mime/Type restriction
         String mimeType = getIntent().getType();
         if (mimeType != null) {
-            if (!MimeTypeHelper.isMimeTypeKnown(this, mimeType)) {
+            if (!MimeTypeHelper.isMimeTypeKnown(this, mimeType) &&
+                !MimeTypeHelper.isAndroidCursorMimeType(mimeType)) {
                 Log.i(TAG,
                         String.format(
                                 "Mime type %s unknown, falling back to wildcard.", //$NON-NLS-1$

--- a/src/com/cyanogenmod/filemanager/util/MimeTypeHelper.java
+++ b/src/com/cyanogenmod/filemanager/util/MimeTypeHelper.java
@@ -227,6 +227,17 @@ public final class MimeTypeHelper {
     }
 
     /**
+      * Method that checks whether it is a special android cursor mimetype
+      * that we don't support and should filter it all
+      *
+      * @param mimeType The mime type to be checked
+      * @return true if mime type is known, false otherwise
+      */
+     public static final boolean isAndroidCursorMimeType(String mimeType) {
+         return mimeType.startsWith("vnd.android.cursor");
+     }
+
+    /**
      * Method that checks whether a certain mime type is known to
      * the application.
      *


### PR DESCRIPTION
We don't support vnd.android.cursor mimetype,
the return result is never be expected to caller.
Ideally, we should filter that mimetype in AndroidManifest.xml,
however we currently accept */* mimetype and there is no
way to exclude a specific mimetype.

FEIJ-1138 FEIJ-1140 FEIJ-1141

Change-Id: I407159c5f5283e4d5cec2ec129a7643723bc8602