### PR TITLE
CMFM: Recognise .opus file extension

### DIFF
--- a/res/raw/mime_types.properties
+++ b/res/raw/mime_types.properties
@@ -252,6 +252,7 @@ mp3   = AUDIO    | audio/mpeg                       | fso_type_audio_drawable
 mpga  = AUDIO    | audio/mpeg                       | fso_type_audio_drawable
 oga   = AUDIO    | audio/ogg                        | fso_type_audio_drawable
 ogg   = AUDIO    | audio/ogg                        | fso_type_audio_drawable
+opus  = AUDIO    | audio/ogg                        | fso_type_audio_drawable
 spx   = AUDIO    | audio/ogg                        | fso_type_audio_drawable
 eol   = AUDIO    | audio/vnd.digital-winds          | fso_type_audio_drawable
 dts   = AUDIO    | audio/vnd.dts                    | fso_type_audio_drawable


### PR DESCRIPTION
*.opus files are getting more popular nowadays.
Recognise them as part of the audio/opus MIME type.

RM-290

Change-Id: Icfcce9ae15a50a74f2268120327ee22921c47eac
(cherry picked from commit dd4956d3881a9a329e99d468ca605b7353f8ad00)