### PR TITLE
FileManager: Editor: Fix race on completion wait/notify

### DIFF
--- a/src/com/cyanogenmod/filemanager/activities/EditorActivity.java
+++ b/src/com/cyanogenmod/filemanager/activities/EditorActivity.java
@@ -274,6 +274,7 @@ public class EditorActivity extends Activity implements TextWatcher {
     private class AsyncReader implements AsyncResultListener {
 
         final Object mSync = new Object();
+        boolean mReadDoneLocked = false;
         ByteArrayOutputStream mByteBuffer = null;
         ArrayList<String> mBinaryBuffer = null;
         SpannableStringBuilder mBuffer = null;
@@ -325,6 +326,7 @@ public class EditorActivity extends Activity implements TextWatcher {
         @Override
         public void onAsyncExitCode(int exitCode) {
             synchronized (this.mSync) {
+                mReadDoneLocked = true;
                 this.mSync.notify();
             }
         }
@@ -1277,7 +1279,9 @@ public class EditorActivity extends Activity implements TextWatcher {
 
                         // Wait for
                         synchronized (this.mReader.mSync) {
-                            this.mReader.mSync.wait();
+                            while (!this.mReader.mReadDoneLocked) {
+                                this.mReader.mSync.wait();
+                            }
                         }
 
                         // 100%


### PR DESCRIPTION
The async reader is racing with the completion handler and when reading
a small enough file the notification may happen before the handler ever
waits.

This patch adds a condition flag under the mSync lock and only ever
waits if the completion wasn't done already.

This also fixes a potential spurious wakeup issue with the previous code
where the wait thread could be woken by a spurious wakeup without the
read being completed.

Change-Id: Ie3e6ead942c0f00dbb3e44591be19634706ee206